### PR TITLE
feat: Implement component runtime reactivity with instance-scoped state

### DIFF
--- a/playground/components/Button.zen
+++ b/playground/components/Button.zen
@@ -1,7 +1,16 @@
 <script>
 type Props = {
   onClick?: () => void
-  clicks: number
+  clicks?: number
+}
+
+state count = 0
+
+function handleClick() {
+  count += 1
+  if (onClick) {
+    onClick(count)
+  }
 }
 </script>
 
@@ -13,18 +22,24 @@ type Props = {
   border-radius: 4px;
   cursor: pointer;
   border: none;
+  margin: 4px;
 }
 
 .btn-clicked {
   background: #0056b3;
 }
+
+.btn-large {
+  padding: 12px 24px;
+  font-size: 16px;
+}
 </style>
 
 <button
   class="btn"
-  :class="{ 'btn-clicked': clicks > 0 }"
-  onclick="onClick"
+  :class="{ 'btn-clicked': count > 0, 'btn-large': count > 5 }"
+  onclick="handleClick"
 >
-  Click Me { clicks }
+  Click Me { count }
 </button>
 

--- a/playground/components/Link.zen
+++ b/playground/components/Link.zen
@@ -1,0 +1,11 @@
+<script>
+type Props = {
+  href: string;
+  label: string;
+}
+</script>
+
+<a :href="href">
+  {label}
+</a>
+

--- a/playground/pages/index.zen
+++ b/playground/pages/index.zen
@@ -8,15 +8,40 @@
   function increment() {
     clicks += 1
   }
+
+  function handleClick(count) {
+    console.log('Clicked', count)
+  }
 </script>
 
 <Main title="Home Page">
   <div>
+    <h1>Component Reactivity Test</h1>
     <h2>Welcome to Zenith Phase 3!</h2>
     <p>Total clicks: { clicks }</p>
     <p>This page demonstrates the component system with layouts and components.</p>
-    <Button clicks={clicks} onClick={decrement} />
-    <Button clicks={clicks} onClick={increment} />
+    
+    <div style="margin: 20px 0; padding: 20px; border: 1px solid #ccc; border-radius: 8px;">
+      <h3>Validation UI</h3>
+      <p>Test component reactivity:</p>
+      
+      <div style="margin: 10px 0;">
+        <Button onClick={handleClick} />
+      </div>
+      
+      <div style="margin: 10px 0;">
+        <Link href="/about" label="About Page" />
+      </div>
+      
+      <div style="margin: 10px 0;">
+        <Button />
+      </div>
+      
+      <div style="margin: 10px 0;">
+        <Button clicks={clicks} onClick={decrement} />
+        <Button clicks={clicks} onClick={increment} />
+      </div>
+    </div>
   </div>
 </Main>
 


### PR DESCRIPTION
This PR extends Phase 2 bindings to support component-level reactivity, ensuring component attributes, text content, and event bindings update correctly when component-local state changes.

## Core Changes

### Component Runtime Reactivity
- Extended binding.ts to support instance-scoped component state for text bindings
- Extended bindings.ts to support instance-scoped component state for attribute bindings
- Components now maintain isolated state with per-instance binding graphs
- State variables remain human-readable (no mangling in component scope)

### Component Processing Enhancements
- Updated component-process.ts to inline prop values in text and attribute bindings
- Props are treated as constants and inlined (not reactive)
- Support for :href and other :attr bindings by inlining prop values
- State mutations now explicitly use window.property to ensure setters trigger reactive updates

### New Components
- Added Link.zen component with href and label props (no state required)
- Updated Button.zen to demonstrate local state reactivity

### Bug Fixes
- Fixed Link component rendering issue (props were not being inlined correctly)
- Fixed expression evaluator to handle object literals in :class bindings correctly
- Fixed instance-scoped state access in attribute binding expressions

## Technical Details

### Instance-Scoped State
- Component state is scoped using pattern: __zen_comp_{instanceId}_{stateName}
- Each component instance gets its own state proxy and binding registrations
- State updates only trigger bindings within the same component instance

### Reactive Updates
- Text bindings: { stateName } updates synchronously when state changes
- Attribute bindings: :class and :value expressions re-evaluate when dependencies change
- Updates are scoped to component instance root element
- No full component re-rendering - only affected nodes update

### Binding Registration
- Component bindings are registered with instance-specific selectors
- Bindings are associated with component instance scope via data-zen-instance attribute
- Attribute binding evaluator merges global state and instance-scoped state correctly

## Validation

Updated index.zen with validation UI demonstrating:
- Multiple Button components with independent state
- Link component with props only
- Reactive class bindings based on state
- Console logging from event handlers

## Compatibility

- Phase 2 bindings (pages/layouts) continue to work unchanged
- No breaking changes to existing component API
- Backward compatible with existing Phase 2 runtime system