### PR TITLE
[Fix] 40 ZenLink Fails to open new Tab Edge Case

### DIFF
--- a/router/navigation/ZenLink.zen
+++ b/router/navigation/ZenLink.zen
@@ -59,7 +59,12 @@ function handleClick(event, el) {
       linkHref.startsWith('mailto:') ||
       linkHref.startsWith('tel:') ||
       linkHref.startsWith('javascript:')) {
-    // External/special link - let browser handle it
+    // External/special link - open in new tab if target not specified
+    if (!linkTarget) {
+      el?.setAttribute('target', '_blank')
+      el?.setAttribute('rel', 'noopener noreferrer')
+    }
+    // Let browser handle it
     return
   }
   


### PR DESCRIPTION
## Description
There is a case where the ZenLink click handler gets a null `linkTarget` for external links and doesn't set `target: _blank` for a new tab
Resolves #40 
## System Settings
Browser: Edge
## Regression Testing
None found (internal links work the same)
Legacy `<a>` links work the same
## AC
![20260103-2010-41 3220934](https://github.com/user-attachments/assets/419004d1-c0e4-420a-9945-b0a0d0a6a5ed)
